### PR TITLE
[bugfix] fixing layout and variables for url-field-demo

### DIFF
--- a/demos/url-field-demo.html
+++ b/demos/url-field-demo.html
@@ -15,7 +15,7 @@
     </li>
     <li>Add the directive:
       <hljs>
-        <url-field url="http://www.risevision.com"></url-field>
+<url-field url="'http://www.risevision.com'"></url-field>
       </hljs>
     </li>
   </ul>
@@ -27,7 +27,7 @@
     </li>
     <li>Add the HTML:
       <hljs>
-        <div id="url-field"></div>
+<div id="url-field"></div>
       </hljs>
     </li>
     <li>Call the plugin:
@@ -38,22 +38,22 @@
   <!-- Dynamic Example -->
   <div class="examples">
     <h3>Example</h3>
-    <url-field url="http://www.risevision.com"></url-field>
+    <url-field url="'http://www.risevision.com'"></url-field>
   </div>
 </div>
 
 <script type="text/ng-template" id="angular-script-includes">
-  /components/widget-settings-ui-components/dist/js/angular/url-field.min.js
+/components/widget-settings-ui-components/dist/js/angular/url-field.min.js
 </script>
 
 <script type="text/ng-template" id="jquery-script-includes">
-  /components/widget-settings-ui-components/dist/js/jquery/url-field.min.js
+/components/widget-settings-ui-components/dist/js/jquery/url-field.min.js
 </script>
 
 <script type="text/ng-template" id="jquery-usage">
-  <script type="text/javascript">
-    $urlField.urlField({
-      url: "http://www.risevision.com"
-    });
-  < /script>
+<script type="text/javascript">
+  $urlField.urlField({
+    url: "http://www.risevision.com"
+  });
+< /script>
 </script>


### PR DESCRIPTION
@stulees I had to modify the demo. `http://www.risevision.com` needs to be wrapped in both single quotes and double quotes. And some minor layout fixes.

Please review and merge. Thanks
