### PR TITLE
[Fix] Column and Scroll setting label changes

### DIFF
--- a/dist/locales/en/translation.json
+++ b/dist/locales/en/translation.json
@@ -27,7 +27,7 @@
 			"page": "By Page"
 		},
 		"speed": {
-			"label": "Scroll Speed",
+			"label": "Speed",
 			"slowest": "Slowest",
 			"slow": "Slow",
 			"medium": "Medium",
@@ -35,7 +35,7 @@
 			"fastest": "Fastest"
 		},
 		"pause": {
-			"label": "Scroll Pause",
+			"label": "Pause",
 			"tooltip": "Number of seconds to pause after touch or the end of the list is reached"
 		}
 	},
@@ -56,7 +56,7 @@
 	},
 	"column": {
 		"heading": "Columns",
-		"select-title" : "Select A Column To Add",
+		"select-title" : "Select Columns To Format",
 		"alignment": {
 			"label": "Alignment",
 			"left": "Left",

--- a/src/_locales/en/translation.json
+++ b/src/_locales/en/translation.json
@@ -27,7 +27,7 @@
 			"page": "By Page"
 		},
 		"speed": {
-			"label": "Scroll Speed",
+			"label": "Speed",
 			"slowest": "Slowest",
 			"slow": "Slow",
 			"medium": "Medium",
@@ -35,7 +35,7 @@
 			"fastest": "Fastest"
 		},
 		"pause": {
-			"label": "Scroll Pause",
+			"label": "Pause",
 			"tooltip": "Number of seconds to pause after touch or the end of the list is reached"
 		}
 	},
@@ -56,7 +56,7 @@
 	},
 	"column": {
 		"heading": "Columns",
-		"select-title" : "Select A Column To Add",
+		"select-title" : "Select Columns To Format",
 		"alignment": {
 			"label": "Alignment",
 			"left": "Left",


### PR DESCRIPTION
- Scroll Setting previously was given a group heading and scroll by label changed to "Type", to be consistent now removing "Scroll" for speed and pause labels
- As requested, changing Column Selector select-title to accommodate the use of Column Selector when formatting columns are optional
