### PR TITLE
Updating of packages and gulp tasks

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,24 +2,24 @@
   "use strict";
 
   var gulp = require("gulp");
-  var spawn = require("spawn-cmd").spawn;
   var gutil = require("gulp-util");
   var connect = require("gulp-connect");
   var html2string = require("gulp-html2string");
   var html2js = require("gulp-html2js");
   var path = require("path");
   var rename = require("gulp-rename");
-  var clean = require("gulp-clean");
   var concat = require("gulp-concat");
   var bump = require("gulp-bump");
   var sass = require("gulp-sass");
   var minifyCSS = require("gulp-minify-css");
   var fs = require("fs");
-  var runSequence = require("gulp-run-sequence");
+  var runSequence = require("run-sequence");
   var es = require("event-stream");
   var jshint = require("gulp-jshint");
   var uglify = require("gulp-uglify");
   var factory = require("widget-tester").gulpTaskFactory;
+  var bower = require("gulp-bower");
+  var del = require("del");
 
   var subcomponents = fs.readdirSync("src")
     .filter(function(file) {
@@ -32,14 +32,16 @@
       return fs.statSync(path.join("src/_angular", file)).isDirectory();
     });
 
-  gulp.task("clean-dist", function () {
-    return gulp.src("dist", {read: false})
-      .pipe(clean());
+  gulp.task("clean-bower", function(cb){
+    del(["./components/**"], cb);
   });
 
-  gulp.task("clean-tmp", function () {
-    return gulp.src("tmp", {read: false})
-      .pipe(clean());
+  gulp.task("clean-dist", function (cb) {
+    del(['./dist/**'], cb);
+  });
+
+  gulp.task("clean-tmp", function (cb) {
+    del(['./tmp/**'], cb);
   });
 
   gulp.task("clean", ["clean-dist", "clean-tmp"]);
@@ -189,6 +191,13 @@
 
   gulp.task("test", function(cb) {
     runSequence("build", "e2e:server", "e2e:test", "e2e:test-ng", "e2e:server-close", "test:metrics", cb);
+  });
+
+  gulp.task("bower-clean-install", ["clean-bower"], function(cb){
+    return bower().on("error", function(err) {
+      console.log(err);
+      cb();
+    });
   });
 
   gulp.task("default", ["build"]);

--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
     "url": "https://github.com/Rise-Vision/widget-settings-ui-components/issues"
   },
   "devDependencies": {
-    "casperjs": "^1.1.0-beta3",
-    "chai": "~1.9.1",
     "chai-as-promised": "~4.1.1",
+    "del": "~1.1.1",
     "event-stream": "^3.1.5",
     "express": "^4.6.1",
     "gulp": "~3.8.1",
+    "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.1.8",
-    "gulp-clean": "^0.3.1",
     "gulp-concat": "^2.2.0",
     "gulp-connect": "~2.0.5",
     "gulp-html2js": "^0.1.0",
@@ -38,7 +37,7 @@
     "gulp-minify-css": "^0.3.5",
     "gulp-protractor": "~0.0.8",
     "gulp-rename": "~1.2.0",
-    "gulp-run-sequence": "^0.3.2",
+    "run-sequence": "^0.3.2",
     "gulp-sass": "^0.7.2",
     "gulp-uglify": "^0.3.1",
     "gulp-util": "~2.2.17",
@@ -55,7 +54,6 @@
     "mocha": "~1.20.1",
     "phantomjs": "^1.9.7-9",
     "protractor": "~1.0.0",
-    "spawn-cmd": "0.0.2",
     "widget-tester": "git://github.com/Rise-Vision/widget-tester.git"
   },
   "homepage": "https://github.com/Rise-Vision/widget-settings-ui-components"


### PR DESCRIPTION
- removed some unnecessary node packages from package.json
- added `gulp-bower` and `del` packages
- `gulp-run-sequence` deprecated, using `run-sequence` instead
- `gulp-clean` deprecated, using recommended use of `del`
- adding `bower-clean-install` gulp task to gulp file for easy removal and re-install of the bower components